### PR TITLE
feat(devcontainer): Podman + Fedora 42 dev environment and CI

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -1,0 +1,6 @@
+FROM fedora:42
+RUN dnf install -y git curl unzip && dnf clean all \
+    && curl -fsSL https://bun.com/install | bash
+ENV BUN_INSTALL="/root/.bun"
+ENV PATH="/root/.bun/bin:$PATH"
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+  "name": "ANA App",
+  "build": { "dockerfile": "Containerfile" },
+  "forwardPorts": [5173],
+  "portsAttributes": {
+    "5173": { "label": "Vite dev server", "onAutoForward": "openBrowser" }
+  },
+  "postCreateCommand": "bun install",
+  "remoteEnv": { "NODE_ENV": "development" }
+}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,12 +24,22 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: fedora:42
     steps:
+      - name: Install system dependencies
+        run: dnf install -y git curl unzip
+
+      - name: Install Bun
+        run: curl -fsSL https://bun.com/install | bash
+
+      - name: Add Bun to PATH
+        run: |
+          echo "$HOME/.bun/bin" >> $GITHUB_PATH
+          echo "BUN_INSTALL=$HOME/.bun" >> $GITHUB_ENV
+
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Install bun
-        uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/README.md
+++ b/README.md
@@ -131,15 +131,35 @@ This regenerates all the JSON files the app reads from the CSV and validates the
 
 ## Getting started
 
-**Prerequisite:** [Bun](https://bun.sh) ≥ 1.x — install with `curl -fsSL https://bun.sh/install | bash`.
+Requires [Podman](https://podman.io/) and [podman-compose](https://github.com/containers/podman-compose).
+No other tools needed on the host. The container image runs Fedora 42.
 
 ```bash
-bun install          # install dependencies
-bun run dev          # start local dev server at http://localhost:5173
-bun run build        # production build (outputs to build/)
-bun run preview      # preview the production build locally
-bun run check        # Svelte type-checking
-bun run test         # run the test suite (Vitest)
+sudo dnf install podman podman-compose   # Fedora / WSL Fedora
+```
+
+> **Windows / WSL 2** — install WSL 2 first (`wsl --install -d FedoraLinux-42`), then run all commands inside WSL.
+
+### Start the dev server
+
+```bash
+podman-compose up
+```
+
+Open <http://localhost:5173>.
+
+### Devcontainer (VS Code / Podman Desktop / GitHub Codespaces)
+
+Open the repo in a devcontainer-aware editor. `bun install` runs automatically.  
+VS Code: set `"docker.dockerPath": "podman"` in your user settings.
+
+### Other commands (run inside the container)
+
+```bash
+podman exec ana-dev bun run build        # production build
+podman exec ana-dev bun run check        # type-check
+podman exec ana-dev bun run test         # unit tests
+podman exec ana-dev bun run data:refresh # regenerate + validate reference data
 ```
 
 Set `BASE_PATH=/repo-name` when building for GitHub Pages sub-path deploys.

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,11 @@
+services:
+  dev:
+    container_name: ana-dev
+    build:
+      context: .
+      dockerfile: .devcontainer/Containerfile
+    volumes:
+      - .:/workspace:Z        # :Z sets SELinux label — required on Fedora/RHEL
+    working_dir: /workspace
+    network_mode: host        # bypasses nftables (unsupported in WSL2 kernel); port 5173 is directly accessible
+    command: sh -c "bun install && bun run dev"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,4 +2,7 @@ import tailwindcss from '@tailwindcss/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
-export default defineConfig({ plugins: [tailwindcss(), sveltekit()] });
+export default defineConfig({
+	plugins: [tailwindcss(), sveltekit()],
+	server: { host: true }
+});


### PR DESCRIPTION
## Summary

- Adds a Podman-based dev environment using Fedora 42 as the base image everywhere (local + CI)
- `podman-compose up` builds the image, installs deps, and starts the Vite dev server at http://localhost:5173
- CI `build` job now runs inside a `fedora:42` container for consistency with local dev
- `network_mode: host` works around the WSL2 nftables incompatibility
- `container_name: ana-dev` makes `podman exec ana-dev ...` predictable

## Files changed

| File | Change |
|------|--------|
| `.devcontainer/Containerfile` | Fedora 42 base, Bun installed via curl script |
| `.devcontainer/devcontainer.json` | Port 5173 forwarded, `bun install` on create |
| `compose.yml` | `podman-compose up` dev service with host networking and `:Z` SELinux volume label |
| `vite.config.ts` | `server.host: true` — binds `0.0.0.0` inside container |
| `.github/workflows/deploy.yml` | `build` job runs in `fedora:42` container, Bun via curl |
| `README.md` | Getting started replaced with Podman-only container guide |

## Test plan

- [ ] `podman-compose up` builds successfully and dev server starts at http://localhost:5173
- [ ] `podman exec ana-dev bun run check` passes with zero errors
- [ ] `podman exec ana-dev bun run test` all tests pass
- [ ] CI workflow passes on push