### PR TITLE
fix(tests): force Vite to bundle Zod in node test environment

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,12 @@ import path from 'path';
 
 export default defineConfig({
 	plugins: [svelte({ hot: false })],
+	ssr: {
+		// Zod 4 is ESM-only ("type":"module") but some environments pick up
+		// the CJS stub before exports are ready. Force Vite to bundle it so
+		// `z` is always fully initialised when test modules import it.
+		noExternal: ['zod']
+	},
 	test: {
 		environment: 'node',
 		include: ['src/**/__tests__/**/*.test.ts']


### PR DESCRIPTION
Zod 4 is ESM-first. In some Bun/vitest environments the runtime picks up the CJS stub before exports.z is assigned, causing "undefined is not an object" in CI. ssr.noExternal: ['zod'] forces Vite to transform the package so z is always fully initialised when test modules import it.