### PR TITLE
feat(layout): show framework modal on first load / cleared localStorage

### DIFF
--- a/src/lib/stores/__tests__/metricStore.test.ts
+++ b/src/lib/stores/__tests__/metricStore.test.ts
@@ -56,10 +56,10 @@ describe('loadMetrics — frameworkUpdated', () => {
 		metricStore.referenceJson = null;
 	});
 
-	it('returns frameworkUpdated: false on first load (no stored generatedAt)', async () => {
+	it('returns frameworkUpdated: true on first load (no stored generatedAt)', async () => {
 		mockFetch('2026-05-22T10:00:00.000Z');
 		const { frameworkUpdated } = await loadMetrics();
-		expect(frameworkUpdated).toBe(false);
+		expect(frameworkUpdated).toBe(true);
 	});
 
 	it('returns frameworkUpdated: false when generatedAt is unchanged', async () => {

--- a/src/lib/stores/metricStore.svelte.ts
+++ b/src/lib/stores/metricStore.svelte.ts
@@ -117,10 +117,9 @@ export async function loadMetrics(): Promise<{ frameworkUpdated: boolean }> {
 		const json = await loadReference();
 		const incoming = (json as Record<string, any>).generatedAt as string | undefined;
 
-		// Detect framework change: new generatedAt differs from a previously-stored non-null value.
-		// First-time loads (storedAt === null) are not "updates" — the user has no stale data.
+		// Detect framework change: generatedAt differs from the stored value (null counts as different).
 		const storedAt = metricStore.generatedAt;
-		const frameworkUpdated = !!(incoming && storedAt && incoming !== storedAt);
+		const frameworkUpdated = !!(incoming && incoming !== storedAt);
 
 		// Skip custom rows re-merge when the framework has changed — old custom MET_IDs may
 		// no longer exist in the new schema. The caller will wipe the custom rows.

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -369,9 +369,8 @@
 	<div class="modal-box max-w-md">
 		<h3 class="text-base-content text-lg font-bold">Framework updated</h3>
 		<p class="text-base-content/80 py-3 text-sm">
-			The ANA reference framework has been updated since your last visit. Your uploaded data,
-			stored results, and any custom reference rows have been cleared — please re-upload your
-			CSV to continue your analysis.
+			The ANA reference framework has been updated. Any stored results or custom reference rows
+			have been cleared — please re-upload your CSV to run your analysis.
 		</p>
 		<div class="modal-action">
 			<button class="btn btn-primary btn-sm" onclick={() => (showFrameworkModal = false)}>


### PR DESCRIPTION
Previously frameworkUpdated required a non-null storedAt, so first-time visitors and users with cleared localStorage never saw the notice. Remove the storedAt guard so the modal fires whenever incoming !== storedAt (including null). Update modal copy and test expectation accordingly.