### PR TITLE
fix: framework modal and localStorage cleanup

### DIFF
--- a/src/lib/stores/__tests__/metricStore.test.ts
+++ b/src/lib/stores/__tests__/metricStore.test.ts
@@ -56,10 +56,10 @@ describe('loadMetrics — frameworkUpdated', () => {
 		metricStore.referenceJson = null;
 	});
 
-	it('returns frameworkUpdated: true on first load (no stored generatedAt)', async () => {
+	it('returns frameworkUpdated: false on first load (no stored generatedAt)', async () => {
 		mockFetch('2026-05-22T10:00:00.000Z');
 		const { frameworkUpdated } = await loadMetrics();
-		expect(frameworkUpdated).toBe(true);
+		expect(frameworkUpdated).toBe(false);
 	});
 
 	it('returns frameworkUpdated: false when generatedAt is unchanged', async () => {

--- a/src/lib/stores/flagStore.svelte.ts
+++ b/src/lib/stores/flagStore.svelte.ts
@@ -1,6 +1,6 @@
 import { browser } from '$app/environment';
 
-const STORAGE_KEY = 'ana_flag_store_v2';
+const STORAGE_KEY = 'ana_flag_store';
 
 export interface FlagState {
 	flaggedResult: Record<string, any>[] | null;

--- a/src/lib/stores/metricStore.svelte.ts
+++ b/src/lib/stores/metricStore.svelte.ts
@@ -117,9 +117,9 @@ export async function loadMetrics(): Promise<{ frameworkUpdated: boolean }> {
 		const json = await loadReference();
 		const incoming = (json as Record<string, any>).generatedAt as string | undefined;
 
-		// Detect framework change: generatedAt differs from the stored value (null counts as different).
+		// Detect framework change: requires a prior stored version to compare against.
 		const storedAt = metricStore.generatedAt;
-		const frameworkUpdated = !!(incoming && incoming !== storedAt);
+		const frameworkUpdated = !!(incoming && storedAt && incoming !== storedAt);
 
 		// Skip custom rows re-merge when the framework has changed — old custom MET_IDs may
 		// no longer exist in the new schema. The caller will wipe the custom rows.

--- a/src/lib/stores/metricStore.svelte.ts
+++ b/src/lib/stores/metricStore.svelte.ts
@@ -56,8 +56,8 @@ function flattenMetrics(json: unknown): MetricMap {
 	return map;
 }
 
-export const STORAGE_KEY = 'ana_metric_store_v2';
-export const CUSTOM_ROWS_KEY = 'ana_custom_reference_v1';
+export const STORAGE_KEY = 'ana_metric_store';
+export const CUSTOM_ROWS_KEY = 'ana_custom_reference';
 
 export interface MetricStoreState {
 	referenceJson: Record<string, any> | null;

--- a/src/lib/stores/resultsFilterStore.svelte.ts
+++ b/src/lib/stores/resultsFilterStore.svelte.ts
@@ -1,6 +1,6 @@
 import { browser } from '$app/environment';
 
-const STORAGE_KEY = 'ana_results_filters_v1';
+const STORAGE_KEY = 'ana_results_filters';
 
 type FilterState = {
 	selectedUoas: string[] | null;

--- a/src/routes/results/+page.svelte
+++ b/src/routes/results/+page.svelte
@@ -100,6 +100,8 @@
 	const referenceJson = $derived(metricStore.referenceJson);
 	const metadataCols = $derived(flagStore.metadataCols ?? ([] as string[]));
 	const hasData = $derived(flagStore.flaggedResult !== null && flagged.length > 0);
+	let everHadData = $state(false);
+	$effect(() => { if (hasData) everHadData = true; });
 
 	const systems = $derived<System[]>(
 		Array.isArray(referenceJson?.systems)
@@ -542,7 +544,7 @@
 		filterStore.selectedGroupValues;
 		filterStore.indSelectedSystems;
 		filterStore.indSelectedFactors;
-		persistFilters();
+		if (everHadData) persistFilters();
 	});
 
 	// ── Observers: scroll spy ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Fix 20**: Revert Fix 19's loose `frameworkUpdated` condition — restore `storedAt &&` guard so the framework-updated modal only fires for returning users (storedAt is non-null), never for first-time visitors who have nothing stale to warn about
- **Fix 21**: Remove `_v1`/`_v2` version suffixes from four localStorage keys (`ana_metric_store`, `ana_flag_store`, `ana_results_filters`, `ana_custom_reference`) — the `generatedAt` timestamp in `reference.json` already handles schema migration detection, making manual versioning redundant
- **Fix 21**: Guard filter persistence with `everHadData` — filter state is only written to localStorage once data has been uploaded in the current session; a fresh session with no uploaded data writes nothing

## Test plan

- [ ] Fresh browser (clear all localStorage) → reload → no framework modal appears
- [ ] Simulate version change: DevTools → edit `ana_metric_store` key, change `generatedAt` to an old value → reload → modal appears, stores cleared
- [ ] Same version reload → no modal
- [ ] Upload CSV → navigate to results → `ana_results_filters` key appears in localStorage (no `_v1` suffix)
- [ ] Clear results in same session → filter state still persisted (`everHadData` remains true)
- [ ] Fresh session, no upload → results page → `ana_results_filters` key absent
- [ ] No old `_v2`/`_v1` keys visible in DevTools localStorage
- [ ] `bun run test --run` → 319/319 pass